### PR TITLE
Add sleep in sending fragments

### DIFF
--- a/src/escpos/escpos.py
+++ b/src/escpos/escpos.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import textwrap
 import warnings
+import time
 from abc import ABCMeta, abstractmethod  # abstract base class support
 from re import match as re_match
 from types import TracebackType
@@ -244,6 +245,7 @@ class Escpos(object, metaclass=ABCMeta):
                     impl=impl,
                     fragment_height=fragment_height,
                 )
+                time.sleep(0.3)
             return
 
         if impl == "bitImageRaster":


### PR DESCRIPTION
Adding sleep prevents "USBTimeoutError: [Errno 110] Operation timed out".

### Description


### Tested with
_If applicable, please describe with which device you have tested._